### PR TITLE
fix: accept special language "text" as a valid prop type

### DIFF
--- a/src/runtime/component.ts
+++ b/src/runtime/component.ts
@@ -7,7 +7,7 @@ import type { HighlightOptions } from './types'
 export default defineComponent({
   props: {
     code: String,
-    lang: String as PropType<BundledLanguage>,
+    lang: String as PropType<BundledLanguage | "text" | "txt" | "plain">,
     highlightOptions: Object as PropType<HighlightOptions>,
     as: { type: String, default: 'pre' },
     unwrap: { type: Boolean, default: undefined },


### PR DESCRIPTION
Closes #42 